### PR TITLE
Fix #3 and Tests

### DIFF
--- a/src/angular2-pubsub.service.spec.ts
+++ b/src/angular2-pubsub.service.spec.ts
@@ -12,7 +12,7 @@ describe('PubSubService', (): void => {
 
     describe('$sub', (): void => {
         it('should throw an error when event is falsy', (): void => {
-            expect(pubService.$sub.bind(undefined)).toThrow();
+            expect(() => pubService.$sub(undefined)).toThrow();
         });
 
         it('should return an observable when there is no callback', (): void => {
@@ -30,7 +30,7 @@ describe('PubSubService', (): void => {
 
     describe('$pub', (): void => {
         it('should throw an error when event is falsy', (): void => {
-            expect(pubService.$pub.bind(undefined)).toThrow();
+            expect(() => pubService.$pub(undefined)).toThrow();
         });
 
         it('should do nothing when an event is not registered', (): void => {

--- a/src/angular2-pubsub.service.spec.ts
+++ b/src/angular2-pubsub.service.spec.ts
@@ -33,8 +33,8 @@ describe('PubSubService', (): void => {
             expect(pubService.$pub.bind(undefined)).toThrow();
         });
 
-        it('should throw an error when event is not registered', (): void => {
-            expect(pubService.$pub.bind('not-registered')).toThrow();
+        it('should do nothing when an event is not registered', (): void => {
+            expect(() => pubService.$pub('not-registered')).not.toThrow();
         });
 
         it('should publish with parameters if the event is registered', (): void => {

--- a/src/angular2-pubsub.service.ts
+++ b/src/angular2-pubsub.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -21,7 +21,7 @@ export class PubSubService implements IPubSubService {
 		}
 
 		if (this.events[event] === undefined) {
-			this.events[event] = new BehaviorSubject<any>(0);
+			this.events[event] = new ReplaySubject<any>();
 		}
 
 		if (typeof callback !== 'function') {

--- a/src/angular2-pubsub.service.ts
+++ b/src/angular2-pubsub.service.ts
@@ -35,7 +35,7 @@ export class PubSubService implements IPubSubService {
 		if (!event) {
 			throw new Error(`[${ServiceName}] => Publish method must get event name.`);
 		} else if (!this.events[event]) {
-			throw new Error(`[${ServiceName}] => No recorded events found for ${event}.`);
+			return;
 		}
 
 		this.events[event].next(eventObject);


### PR DESCRIPTION
This pull request should fix issue #3, removing the error that is thrown when an event has no subscribers. During this fix, I also noticed that several tests were written using the bind() function, like so:

`expect(pubService.$sub.bind(undefined)).toThrow();`

This syntax binds the `this` keyword of the function to `undefined`. I believe the intent here was to pass `undefined` as the first argument to the function. To fix this issue, I replaced the test with arrow functions:

`expect(() => pubService.$sub(undefined)).toThrow();`

This syntax should correctly pass `undefined` as the `event` argument of the `$sub` method.